### PR TITLE
fix: change projection epsg=102015 to "ESRI:102015"

### DIFF
--- a/notebooks/1_fundamentos/02_sistemas_coordenadas_projecoes.ipynb
+++ b/notebooks/1_fundamentos/02_sistemas_coordenadas_projecoes.ipynb
@@ -93,7 +93,7 @@
     "\n",
     "# Vamos mudar para outro sistema (Projeção Cônica Conforme de Lambert)\n",
     "# É como redesenhar o mapa em outro tipo de papel\n",
-    "estados_lambert = estados.to_crs(epsg=102015)\n",
+    "estados_lambert = estados.to_crs("ESRI:102015")\n",
     "\n",
     "# Comparando os dois mapas lado a lado\n",
     "# Como colocar dois mapas na parede para ver as diferenças\n",


### PR DESCRIPTION
Encontrei um pequeno erro no arquivo `02_sistemas_coordenadas_projecoes.ipynb` onde o código usava o epsg=102015 que não é válido. Substituí pelo "ESRI:102015", que é válido, conforme documentação no site [https://spatialreference.org/](url).

Obrigado pelo projeto — tá muito legal!